### PR TITLE
Add support for Windows

### DIFF
--- a/bin/glsl2gif.js
+++ b/bin/glsl2gif.js
@@ -62,14 +62,27 @@ const tmpDir = tmpObj.name;
 
 // Render frames
 let time = 0;
-range(frames).forEach(i => {
-  execFileSync(
-    `${__dirname}/wrapper.js`,
-    [width, height, file, time, uniform, `${tmpDir}/frame${pad5(i)}.png`],
-    { stdio: cli.flags.verbose ? 'inherit' : 'ignore' }
-  );
-  time += delay;
-});
+if (process.platform !== 'win32') {
+  range(frames).forEach(i => {
+    execFileSync(
+      `${__dirname}/wrapper.js`,
+      [width, height, file, time, uniform, `${tmpDir}/frame${pad5(i)}.png`],
+      { stdio: cli.flags.verbose ? 'inherit' : 'ignore' }
+    );
+    time += delay;
+  });
+} else {
+  const spawnSync = require('child_process').spawnSync;
+
+  range(frames).forEach(i => {
+    spawnSync(
+      'cmd.exe',
+      ['/c', `${__dirname}\\wrapper.bat`, `${__dirname}\\wrapper.js`, width, height, file, time, uniform, `${tmpDir}/frame${pad5(i)}.png`],
+      { stdio: cli.flags.verbose ? 'inherit' : 'ignore' }
+    );
+    time += delay;
+  });
+}
 
 // Convert PNG images to GIF
 const encoder = new GIFEncoder(width, height);

--- a/bin/glsl2png.js
+++ b/bin/glsl2png.js
@@ -35,8 +35,20 @@ const [width, height] = size.match(/^\d+x\d+$/) ? size.split('x') : [600, 600];
 const time = cli.flags.time || 0;
 const uniform = cli.flags.uniform || '{}';
 
-execFileSync(
-  `${__dirname}/wrapper.js`,
-  [width, height, file, time, uniform, out],
-  { stdio: cli.flags.verbose ? 'inherit' : 'ignore' }
-);
+if (process.platform !== 'win32') {
+  execFileSync(
+    `${__dirname}/wrapper.js`,
+    [width, height, file, time, uniform, out],
+    { stdio: cli.flags.verbose ? 'inherit' : 'ignore' }
+  );
+} else {
+  const spawnSync = require('child_process').spawnSync;
+
+  spawnSync(
+    'cmd.exe',
+    ['/c', `${__dirname}\\wrapper.bat`, `${__dirname}\\wrapper.js`, 
+    width, height, file, time, uniform, out],
+    { stdio: cli.flags.verbose ? 'inherit' : 'ignore' }
+  );
+
+}

--- a/bin/wrapper.bat
+++ b/bin/wrapper.bat
@@ -1,0 +1,2 @@
+shift
+node %*


### PR DESCRIPTION
Hi, glsl2img is nice!
I try to support for windows.
thank you.

If you use this patch, you have to get GTK 2 bundle for Win32 or Win64. Unzip the contents in C:\GTK.

- http://ftp.gnome.org/pub/GNOME/binaries/win32/gtk+/2.24/gtk+-bundle_2.24.10-20120208_win32.zip
- http://ftp.gnome.org/pub/GNOME/binaries/win64/gtk+/2.22/gtk+-bundle_2.22.1-20101229_win64.zip